### PR TITLE
fix: convert Buffer constructor to new methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Example
   var StreamSearch = require('streamsearch'),
       inspect = require('util').inspect;
 
-  var needle = new Buffer([13, 10]), // CRLF
+  var needle = Buffer.from([13, 10]), // CRLF
       s = new StreamSearch(needle),
       chunks = [
-        new Buffer('foo'),
-        new Buffer(' bar'),
-        new Buffer('\r'),
-        new Buffer('\n'),
-        new Buffer('baz, hello\r'),
-        new Buffer('\n world.'),
-        new Buffer('\r\n Node.JS rules!!\r\n\r\n')
+        Buffer.from('foo'),
+        Buffer.from(' bar'),
+        Buffer.from('\r'),
+        Buffer.from('\n'),
+        Buffer.from('baz, hello\r'),
+        Buffer.from('\n world.'),
+        Buffer.from('\r\n Node.JS rules!!\r\n\r\n')
       ];
   s.on('info', function(isMatch, data, start, end) {
     if (data)

--- a/lib/sbmh.js
+++ b/lib/sbmh.js
@@ -14,7 +14,7 @@ function jsmemcmp(buf1, pos1, buf2, pos2, num) {
 
 function SBMH(needle) {
   if (typeof needle === 'string')
-    needle = new Buffer(needle);
+    needle = Buffer.from(needle);
   var i, j, needle_len = needle.length;
 
   this.maxMatches = Infinity;
@@ -25,7 +25,7 @@ function SBMH(needle) {
   this._needle = needle;
   this._bufpos = 0;
 
-  this._lookbehind = new Buffer(needle_len);
+  this._lookbehind = Buffer.alloc(needle_len);
 
   // Initialize occurrence table.
   for (j = 0; j < 256; ++j)
@@ -49,7 +49,7 @@ SBMH.prototype.reset = function() {
 SBMH.prototype.push = function(chunk, pos) {
   var r, chlen;
   if (!Buffer.isBuffer(chunk))
-    chunk = new Buffer(chunk, 'binary');
+    chunk = Buffer.from(chunk, 'binary');
   chlen = chunk.length;
   this._bufpos = pos || 0;
   while (r !== chlen && this.matches < this.maxMatches)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "streamsearch",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "Streaming Boyer-Moore-Horspool searching for node.js",
   "main": "./lib/sbmh",


### PR DESCRIPTION
Hi,

`new Buffer()` has been deprecated, there are new methods: `Buffer.from` and `Buffer.alloc`.
This PR also updated version from `0.1.2` to `0.1.3`, and examples in README.md, please check.

fix #4