### PR TITLE
Refactor license information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
     "boyer-moore",
     "search"
   ],
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://github.com/mscdex/streamsearch/raw/master/LICENSE"
-  }],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/mscdex/streamsearch.git"


### PR DESCRIPTION
Refactored the deprecated style with key licenses in package.json
see https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license