### PR TITLE
Follow NPM license guidelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
     "boyer-moore",
     "search"
   ],
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://github.com/mscdex/streamsearch/raw/master/LICENSE"
-  }],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/mscdex/streamsearch.git"


### PR DESCRIPTION
We've adopted tooling to parse project dependencies and licenses, which unfortunately breaks due to an invalid metadata property in the `package.json` file. The `licenses` property, according to the [NPM Docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license) has been deprecated.