### PR TITLE
fix: use single license field to ensure compatibility with scanners

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
     "boyer-moore",
     "search"
   ],
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://github.com/mscdex/streamsearch/raw/master/LICENSE"
-  }],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/mscdex/streamsearch.git"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
     "search"
   ],
   "license": "MIT",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/mscdex/streamsearch/raw/master/LICENSE"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "http://github.com/mscdex/streamsearch.git"


### PR DESCRIPTION
closes #15 - I am aware this kind of contribution has been dismissed several times before. If the preference is to keep the URL for licenses, the correct *license* field should be included in addition, as is done here.

This will make the license visible in the npm registry, and make it detectable by dependency scanning tools.